### PR TITLE
replaced gwt-dev by commons-lang3

### DIFF
--- a/analyser/pom.xml
+++ b/analyser/pom.xml
@@ -32,9 +32,9 @@
             <version>4.2.3.RELEASE</version>
         </dependency>
         <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-dev</artifactId>
-            <version>2.6.0</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
This pull request replaces `gwt-dev` by `commons-lang3`.
Since gwt-dev contains `org.eclipse.jetty.server.*` the spring-boot autoconfiguration triggers to use jetty as embedded container. But I use Tomcat and receiving `NoClassDefFoundError: org/eclipse/jetty/http/HttpMethod` when any error ocurrs due to activating `JettyEmbeddedErrorHandler`.
From your code I see that `commons-lang3` is the one transitive dependency you're using from `gwt-dev`. 